### PR TITLE
fix(ci): derive NuGet package version from release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,14 +53,26 @@ jobs:
       - name: Restore
         run: dotnet restore Aspeckd.sln
 
+      - name: Derive package version from release tag
+        # Release tags are expected to be semver with an optional leading 'v'
+        # (e.g. v1.2.3 or 1.2.3-rc.1). Strip a leading 'v' so NuGet receives
+        # a valid package version.
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "PACKAGE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Using package version: $VERSION"
+
       - name: Pack
         # The test project has <IsPackable>false/> so only the two source
         # projects (Aspeckd and Aspeckd.Core) will produce .nupkg files.
-        # MinVer reads the git tag checked out above and stamps the version.
+        # Set PackageVersion explicitly from the published release tag to keep
+        # CI output deterministic even if MinVer cannot resolve git metadata.
         run: >
           dotnet pack Aspeckd.sln
           --no-restore
           --configuration Release
+          -p:PackageVersion=${{ env.PACKAGE_VERSION }}
           --output artifacts/
 
       - name: Authenticate to NuGet.org (Trusted Publishing)


### PR DESCRIPTION
## Summary
- derive package version from 
- strip optional leading  (e.g.  -> )
- pass explicit  to MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.

## Why
MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file. in the publish workflow could produce an unexpected version when MinVer/tag graph resolution in CI does not match the release context.

Using the release tag directly makes package versioning deterministic and aligned with the published GitHub Release.

## Validation
- workflow updated in 
- branch pushed and ready for CI on PR
