### PR TITLE
fix: add MinVerVersionOverride and version diagnostic step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,15 +100,43 @@ jobs:
           fi
           echo "Release type and version suffix are aligned (prerelease=$IS_PRERELEASE, version=$VERSION)."
 
+      - name: Diagnose version inputs
+        shell: bash
+        run: |
+          echo "=== Recent git tags ==="
+          git tag --sort=-creatordate | head -20
+          echo ""
+          echo "=== git describe ==="
+          git describe --tags --always
+          echo ""
+          echo "=== MSBuild version properties (Aspeckd) ==="
+          dotnet msbuild src/Aspeckd/Aspeckd.csproj \
+            -p:Version=${{ env.PACKAGE_VERSION }} \
+            -p:PackageVersion=${{ env.PACKAGE_VERSION }} \
+            -p:MinVerVersionOverride=${{ env.PACKAGE_VERSION }} \
+            -getProperty:Version \
+            -getProperty:PackageVersion \
+            -getProperty:MinVerVersion 2>/dev/null || true
+          echo ""
+          echo "=== MSBuild version properties (Aspeckd.Core) ==="
+          dotnet msbuild src/Aspeckd.Core/Aspeckd.Core.csproj \
+            -p:Version=${{ env.PACKAGE_VERSION }} \
+            -p:PackageVersion=${{ env.PACKAGE_VERSION }} \
+            -p:MinVerVersionOverride=${{ env.PACKAGE_VERSION }} \
+            -getProperty:Version \
+            -getProperty:PackageVersion \
+            -getProperty:MinVerVersion 2>/dev/null || true
+
       - name: Pack
-        # Version and PackageVersion are forced from the release tag so MinVer's
-        # fallback (0.0.0-alpha.0.N) can never win.
+        # Version, PackageVersion, and MinVerVersionOverride are all forced from
+        # the release tag so MinVer's fallback (0.0.0-alpha.0.N) can never win.
         run: >
           dotnet pack Aspeckd.sln
           --no-restore
           --configuration Release
           -p:Version=${{ env.PACKAGE_VERSION }}
           -p:PackageVersion=${{ env.PACKAGE_VERSION }}
+          -p:MinVerVersionOverride=${{ env.PACKAGE_VERSION }}
           --output artifacts/
 
       - name: Authenticate to NuGet.org (Trusted Publishing)


### PR DESCRIPTION
## Problem

When a GitHub Release is published, there is a race condition where the git tag may not be immediately visible to `actions/checkout` at fetch time. Since MinVer fires as an MSBuild target during `dotnet pack` and overrides properties set via `-p:Version`/`-p:PackageVersion`, the fallback version (`0.0.0-alpha.0.N`) was being used instead of the tag-derived version.

Confirmed in run [#23603541419](https://github.com/awaldow/aspeckd-dotnet/actions/runs/23603541419/job/68739904132): pack was called with `-p:Version=0.1.6` but produced `Aspeckd.0.0.0-alpha.0.19.nupkg`.

## Fix

- Add `-p:MinVerVersionOverride=${{ env.PACKAGE_VERSION }}` to `dotnet pack`. This is MinVer's own escape hatch — it short-circuits the git walk entirely, so the tag visibility race condition cannot affect the package version.
- Add a **Diagnose version inputs** step before Pack that outputs recent git tags, `git describe`, and the resolved MSBuild version properties for both packable projects. This makes future version issues immediately visible in the logs without needing to dig.